### PR TITLE
Add multi-file upload support

### DIFF
--- a/components/Chat/ChatMessage.js
+++ b/components/Chat/ChatMessage.js
@@ -12,7 +12,7 @@ import { getMessageTTS, exportMessage } from '../../services/api';
 // *** Add showFeedback to the destructured props ***
 const ChatMessage = ({ message, onLikeDislike, onCopy, showFeedback }) => {
     // Destructure message properties, including the new isIdFinal flag
-    const { id, sender, text, is_liked, isIdFinal, chartData, fileData, fileType, fileName, audioData } = message;
+    const { id, sender, text, is_liked, isIdFinal, chartData, attachments = [], audioData } = message;
     const isUser = sender === 'user';
     const isBot = sender === 'bot';
     const isError = sender === 'error';
@@ -161,15 +161,15 @@ const ChatMessage = ({ message, onLikeDislike, onCopy, showFeedback }) => {
                     </div>
                 )}
 
-                {fileData && fileType && (
-                    fileType.startsWith('image/') ? (
-                        <img className="message-image" src={`data:${fileType};base64,${fileData}`} alt={fileName || 'attachment'} />
+                {attachments.map((att, idx) => (
+                    att.fileType && att.fileType.startsWith('image/') ? (
+                        <img key={idx} className="message-image" src={`data:${att.fileType};base64,${att.fileData}`} alt={att.fileName || 'attachment'} />
                     ) : (
-                        <a className="file-attachment" href={`data:${fileType};base64,${fileData}`} download={fileName || 'file'}>
-                            <FaFileAlt /> {fileName}
+                        <a key={idx} className="file-attachment" href={`data:application/octet-stream;base64,${att.fileData}`} download={att.fileName || 'file'}>
+                            <FaFileAlt /> {att.fileName}
                         </a>
                     )
-                )}
+                ))}
                 {audioData && (
                     <audio controls className="audio-attachment" src={`data:audio/wav;base64,${audioData}`}></audio>
                 )}
@@ -256,9 +256,13 @@ ChatMessage.propTypes = {
         is_liked: PropTypes.bool, // Can be null, true, or false
         isIdFinal: PropTypes.bool.isRequired,
         chartData: PropTypes.object,
-        fileData: PropTypes.string,
-        fileType: PropTypes.string,
-        fileName: PropTypes.string,
+        attachments: PropTypes.arrayOf(
+            PropTypes.shape({
+                fileData: PropTypes.string.isRequired,
+                fileType: PropTypes.string,
+                fileName: PropTypes.string,
+            })
+        ),
         audioData: PropTypes.string,
     }).isRequired,
     onLikeDislike: PropTypes.func, // Callback for feedback

--- a/services/api.js
+++ b/services/api.js
@@ -134,7 +134,7 @@ export const deleteFile = (fileId) => {
 
 
 // --- Chat Streaming API Call (Using Fetch for SSE) ---
-export const streamChatMessage = async (sessionId, messageContent, selectedSections, signal, fileData = null, audioData = null, fileType = '') => {
+export const streamChatMessage = async (sessionId, messageContent, selectedSections, signal, attachments = [], audioData = null) => {
     const token = localStorage.getItem('accessToken');
     if (!token) {
         // Handle missing token case early, perhaps redirect or throw specific error
@@ -146,27 +146,22 @@ export const streamChatMessage = async (sessionId, messageContent, selectedSecti
         throw new Error("Session ID is required for streaming.");
     }
 
-    const payload = { content: [{"type": "text","text": messageContent}], sections:selectedSections };
-    if (fileData && fileType) {
-        if (fileType.startsWith('image/')) 
-        {
+    const payload = { content: [{"type": "text","text": messageContent}], sections: selectedSections };
+    attachments.forEach(att => {
+        if (att.type.startsWith('image/')) {
             payload.content.push({
                 "type": "image_url",
-                "image_url": {
-                  "url": `data:${fileType};base64,${fileData}`
-                }
-              });
-        } 
-        else if (fileType === 'application/pdf') 
-        {
+                "file_name": att.name,
+                "image_url": { "url": `data:${att.type};base64,${att.base64}` }
+            });
+        } else {
             payload.content.push({
-                "type": "image_url",
-                "image_url": {
-                  "url": `data:application/pdf;base64,${fileData}`
-                }
-              });
+                "type": att.type,
+                "file_name": att.name,
+                "file_data": att.base64
+            });
         }
-    }
+    });
     if (audioData) {
         payload.content.push({
             "type": "input_audio",


### PR DESCRIPTION
## Summary
- allow selecting and staging multiple files in chat input
- show all attachments in message bubbles
- store files as `attachments` array when parsing messages
- update streaming payload for file uploads

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f73ff8e1c832f8a9f61611096801f