### PR TITLE
Fix attachment types for new API

### DIFF
--- a/pages/ChatPage.js
+++ b/pages/ChatPage.js
@@ -23,6 +23,22 @@ import { FaInfoCircle, FaPlus, FaListUl, FaFileAlt, FaTrash, FaDownload, FaBars,
 import { useLanguage } from '../contexts/LanguageContext';
 import './ChatPage.css';
 
+// Map browser MIME types to API specific file types
+const mapToApiFileType = (mimeType) => {
+    switch (mimeType) {
+        case 'text/csv':
+            return 'file/csv';
+        case 'text/plain':
+            return 'file/txt';
+        case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+            return 'file/docx';
+        case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+            return 'file/xlsx';
+        default:
+            return mimeType;
+    }
+};
+
 const STREAM_TIMEOUT_MS = 120000; // 120 seconds timeout for stream inactivity
 
 const ChatPage = () => {
@@ -249,6 +265,15 @@ const ChatPage = () => {
                                                 }
                                             }
                                             break; }
+                                        case 'file/csv':
+                                        case 'file/txt':
+                                        case 'file/docx':
+                                        case 'file/xlsx':
+                                        case 'file/pdf':
+                                            if (item.file_data) {
+                                                attachments.push({ fileData: item.file_data, fileType: item.type, fileName: item.file_name || 'file' });
+                                            }
+                                            break;
                                         case 'input_audio':
                                             if (item.input_audio && item.input_audio.data) {
                                                 audioData = item.input_audio.data;
@@ -554,7 +579,7 @@ const ChatPage = () => {
             // Normalize attachments for API call
             const apiAttachments = attachments.map(att => ({
                 name: att.fileName || att.name,
-                type: att.fileType || att.type,
+                type: mapToApiFileType(att.fileType || att.type),
                 base64: att.fileData || att.base64
             }));
 

--- a/services/api.js
+++ b/services/api.js
@@ -4,6 +4,22 @@ import axios from 'axios';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://127.0.0.1:8000'; // Fallback
 
+// Map browser MIME types to API specific file types
+const mapToApiFileType = (mimeType) => {
+    switch (mimeType) {
+        case 'text/csv':
+            return 'file/csv';
+        case 'text/plain':
+            return 'file/txt';
+        case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+            return 'file/docx';
+        case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+            return 'file/xlsx';
+        default:
+            return mimeType;
+    }
+};
+
 const api = axios.create({
     baseURL: API_URL + '/api/',
     headers: {
@@ -156,7 +172,7 @@ export const streamChatMessage = async (sessionId, messageContent, selectedSecti
             });
         } else {
             payload.content.push({
-                "type": att.type,
+                "type": mapToApiFileType(att.type),
                 "file_name": att.name,
                 "file_data": att.base64
             });


### PR DESCRIPTION
## Summary
- map browser MIME types to new `file/*` API types
- parse `file/*` items from message history
- normalize attachment types before API call
- update `streamChatMessage` payload with mapped types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f8722cfe8832f8f5c16bf5bc3a2c4