### PR TITLE
Handle PDF as image_url

### DIFF
--- a/services/api.js
+++ b/services/api.js
@@ -170,6 +170,12 @@ export const streamChatMessage = async (sessionId, messageContent, selectedSecti
                 "file_name": att.name,
                 "image_url": { "url": `data:${att.type};base64,${att.base64}` }
             });
+        } else if (att.type === 'application/pdf') {
+            payload.content.push({
+                "type": "image_url",
+                "file_name": att.name,
+                "image_url": { "url": `data:application/pdf;base64,${att.base64}` }
+            });
         } else {
             payload.content.push({
                 "type": mapToApiFileType(att.type),


### PR DESCRIPTION
## Summary
- ensure pdf files are sent as `image_url` instead of regular file data

## Testing
- `npm test -- --watchAll=false` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f8df1a940832fb44a2ab01bfcc417